### PR TITLE
Rm local session frame size checks

### DIFF
--- a/src/session/transcoders.rs
+++ b/src/session/transcoders.rs
@@ -15,9 +15,7 @@ use std::borrow::Borrow;
 
 use amplify::Bipolar;
 
-use crate::transport::{
-    Error, FRAME_PREFIX_SIZE, FRAME_SUFFIX_SIZE, MAX_FRAME_SIZE,
-};
+use crate::transport::{Error, FRAME_PREFIX_SIZE, FRAME_SUFFIX_SIZE};
 
 pub trait Encrypt {
     fn encrypt(&mut self, buffer: impl Borrow<[u8]>) -> Vec<u8>;
@@ -71,9 +69,6 @@ impl Decrypt for PlainTranscoder {
         let frame_len = buffer.len();
         if frame_len < FRAME_PREFIX_SIZE + FRAME_SUFFIX_SIZE {
             return Err(Error::FrameTooSmall(frame_len));
-        }
-        if frame_len > MAX_FRAME_SIZE {
-            return Err(Error::OversizedFrame(frame_len));
         }
         let mut len_buf = [0u8; 2];
         len_buf.copy_from_slice(&buffer[0..2]);

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -182,7 +182,7 @@ pub trait SendFrame {
     /// Sends a single frame of data structured as a byte string. The frame must
     /// already contain LNP framing prefix with size data. The function must
     /// check that the provided data frame length is below the limit defined
-    /// with [`MAX_FRAME_SIZE`] constant.
+    /// with [`MAX_FRAME_SIZE`] constant if a tcp connection is used.
     ///
     /// # Returns
     /// In case of success, number of bytes send (NB: this is larger than the
@@ -193,7 +193,7 @@ pub trait SendFrame {
     /// * [`Error::SocketIo`] if the overlaid protocol errors with I/O error
     ///   type
     /// * [`Error::OversizedFrame`] if the provided data length exceeds
-    ///   [`MAX_FRAME_SIZE`]
+    ///   [`MAX_FRAME_SIZE`] and a tcp connection is used
     // We can't use `impl AsRev<[u8]>` here since with it the trait can't be
     // made into an object
     fn send_frame(&mut self, frame: &[u8]) -> Result<usize, Error>;
@@ -219,8 +219,7 @@ pub trait SendFrame {
     /// receiver with `remote_id`. Function works like [`RecvFrame::recv_frame`]
     /// and is used for the underlying protocols supporting multipeer
     /// connectivity. The frame must already contain LNP framing prefix with
-    /// size data. The function must check that the provided data frame
-    /// length is below the limit defined with [`MAX_FRAME_SIZE`] constant.
+    /// size data.
     ///
     /// # Returns
     /// In case of success, number of bytes send (NB: this is larger than the
@@ -230,8 +229,6 @@ pub trait SendFrame {
     /// # Errors
     /// * [`Error::SocketIo`] if the overlaid protocol errors with I/O error
     ///   type
-    /// * [`Error::OversizedFrame`] if the provided data length exceeds
-    ///   [`MAX_FRAME_SIZE`]
     ///
     /// # Panics
     /// Default implementation panics, since the most of framing protocols do

--- a/src/transport/zeromq.rs
+++ b/src/transport/zeromq.rs
@@ -426,12 +426,7 @@ impl Bipolar for Connection {
 impl RecvFrame for WrappedSocket {
     #[inline]
     fn recv_frame(&mut self) -> Result<Vec<u8>, transport::Error> {
-        let data = self.socket.recv_bytes(0)?;
-        let len = data.len();
-        if len > super::MAX_FRAME_SIZE as usize {
-            return Err(transport::Error::OversizedFrame(len));
-        }
-        Ok(data)
+        Ok(self.socket.recv_bytes(0)?)
     }
 
     fn recv_raw(&mut self, _len: usize) -> Result<Vec<u8>, transport::Error> {
@@ -459,10 +454,6 @@ impl RecvFrame for WrappedSocket {
                 "excessive parts in ZMQ multipart routed frame",
             ));
         }
-        let len = msg.len();
-        if len > super::MAX_FRAME_SIZE as usize {
-            return Err(transport::Error::OversizedFrame(len));
-        }
         Ok(RoutedFrame { hop, src, dst, msg })
     }
 }
@@ -470,12 +461,8 @@ impl RecvFrame for WrappedSocket {
 impl SendFrame for WrappedSocket {
     #[inline]
     fn send_frame(&mut self, data: &[u8]) -> Result<usize, transport::Error> {
-        let len = data.len();
-        if len > super::MAX_FRAME_SIZE as usize {
-            return Err(transport::Error::OversizedFrame(len));
-        }
         self.socket.send(data, 0)?;
-        Ok(len)
+        Ok(data.len())
     }
 
     fn send_raw(&mut self, data: &[u8]) -> Result<usize, transport::Error> {
@@ -490,10 +477,6 @@ impl SendFrame for WrappedSocket {
         dest: &[u8],
         data: &[u8],
     ) -> Result<usize, transport::Error> {
-        let len = data.len();
-        if len > super::MAX_FRAME_SIZE as usize {
-            return Err(transport::Error::OversizedFrame(len));
-        }
         self.socket
             .send_multipart(&[route, source, dest, data], 0)?;
         Ok(data.len())

--- a/tests/zmq.rs
+++ b/tests/zmq.rs
@@ -37,6 +37,11 @@ fn main() {
             .unwrap();
         let frame = session.recv_routed_message().unwrap();
         assert_eq!(frame.msg, b"world");
+        session
+            .send_routed_message(b"tx_new", b"rx", b"rx", &[0; 1024 * 1024])
+            .unwrap();
+        let frame = session.recv_routed_message().unwrap();
+        assert_eq!(frame.msg, [0; 1024 * 1024]);
     });
 
     session.recv_routed_message().unwrap();
@@ -46,6 +51,10 @@ fn main() {
     session.recv_routed_message().unwrap();
     session
         .send_routed_message(b"rx", b"tx_new", b"tx_new", b"world")
+        .unwrap();
+    session.recv_routed_message().unwrap();
+    session
+        .send_routed_message(b"rx", b"tx_new", b"tx_new", &[0; 1024 * 1024])
         .unwrap();
 
     tx.join().unwrap();


### PR DESCRIPTION
This pull requests removes maximum messages size restrictions of the zeromq transports. This is done in accordance to the discussion in #25 .

Removes frame size checks from the zeromq transports and the PlainTranscoder. Adds a unit test to ensure large messages are now routable. 

Updates the docstrings of the SendFrame trait in concert with the changes.