### PR TITLE
Brontozaur: Support connecting with existing tcp stream

### DIFF
--- a/src/session/session.rs
+++ b/src/session/session.rs
@@ -356,6 +356,18 @@ impl BrontozaurSession {
         BrontozaurSession::with_tcp_encrypted(stream, local_key, remote_addr)
     }
 
+    pub fn connect_with(
+        stream: std::net::TcpStream,
+        local_key: secp256k1::SecretKey,
+        remote_node: NodeAddr,
+    ) -> Result<Self, Error> {
+        BrontozaurSession::with_connect_tcp_encrypted(
+            stream,
+            local_key,
+            remote_node,
+        )
+    }
+
     pub fn connect(
         local_key: secp256k1::SecretKey,
         remote_node: NodeAddr,
@@ -430,6 +442,24 @@ impl<const LEN_SIZE: usize>
             local_key,
             encrypted::Connection::with(stream, remote_addr),
         )
+    }
+
+    fn with_connect_tcp_encrypted(
+        stream: std::net::TcpStream,
+        local_key: secp256k1::SecretKey,
+        remote_node: NodeAddr,
+    ) -> Result<Self, Error> {
+        let mut connection =
+            encrypted::Connection::with(stream, remote_node.addr);
+        let transcoder = NoiseTranscoder::new_initiator(
+            local_key,
+            remote_node.public_key(),
+            &mut connection,
+        )?;
+        Ok(Self {
+            transcoder,
+            connection,
+        })
     }
 
     fn connect_tcp_encrypted(


### PR DESCRIPTION
This supports creating connecting Brontozaur sessions with an external tcp stream, for example one spawned by a socks proxy.

Example usage:

```
use internet2::addr::{InetSocketAddr, LocalNode};
use std::str::FromStr;
use socks::Socks5Stream;
use internet2::session::BrontozaurSession;

dummy = InetSocketAddr::from_str("127.0.0.1:12345").unwrap();
let local_node = LocalNode::new(bitcoin::secp256k1::SECP256K1)
let socks_stream = Socks5Stream::connect(
    "127.0.0.1:9050",
    "fdbzgjl7vtezlzwyx6xipvbczq3cuhvxfnypoljuctnl5mqc4bwrr7ad.onion"
).unwrap();
let mut stream = socks_stream.into_inner();
let session = BrontozaurSession::with(stream, local_node.private_key(), dummy).unwrap();
```